### PR TITLE
set flash start addr to 0x4000

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,7 +8,7 @@ pub const atsamd51j19 = .{
         .atdf = .{ .path = "./board/ATSAMD51J19A.atdf" },
     },
     .memory_regions = &.{
-        .{ .kind = .flash, .offset = 0x00000000, .length = 512 * 1024 }, // Embedded Flash
+        .{ .kind = .flash, .offset = 0x00004000, .length = 512 * 1024 }, // Embedded Flash
         .{ .kind = .ram, .offset = 0x20000000, .length = 192 * 1024 }, // Embedded SRAM
         .{ .kind = .ram, .offset = 0x47000000, .length = 8 * 1024 }, // Backup SRAM
         .{ .kind = .flash, .offset = 0x00804000, .length = 512 }, // NVM User Row


### PR DESCRIPTION
Address `0` is reserved for the bootloader, by loading our app at address `0x4000` the bootloader will invoke us.

With this I was able to build/load the uf2 file and see it blink the LED.