### PR TITLE
Stack Fixes and Audio Shapes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -277,6 +277,7 @@ pub fn add_os(
             .file = d.builder.path("src/os/linker.ld"),
             .generate = .none, // Don't generate microzig's default linker script
         },
+        .stack = .{ .symbol_name = "__stack" }, // Exported by linker script
     });
     // Install both ELF and UF2 formats
     mb.install_firmware(fw, .{ .format = .elf });

--- a/showcase/carts/audio/src/main.zig
+++ b/showcase/carts/audio/src/main.zig
@@ -12,42 +12,77 @@ const white = DisplayColor{ .b = 31, .g = 63, .r = 31 };
 const black = DisplayColor{ .b = 0, .g = 0, .r = 0 };
 const gray = DisplayColor{ .b = 1, .g = 2, .r = 1 };
 const lt_blue = DisplayColor{ .b = 31, .g = 15, .r = 7 };
+const yellow = DisplayColor{ .b = 0, .g = 63, .r = 31 };
 
 // Compute equal temperment frequency from midi note number
 // Compatible with fractional note numbers for microtonal adjustment
 fn freqFromMidi(midi: f32) f32 {
-    return 440.0 * @exp2((midi - 69.0) / 12.0);
+    // exp2 causes illegal instruction, so we use exp instead to emulate
+    return 440.0 * @exp((midi - 69.0) * (@log(2.0) / 12.0));
 }
 
-const c_maj = [_]f32 {
-    60, // C4
-    62, // D4
-    64, // E4
-    65, // F4
-    67, // G4
-    69, // A4
-    71, // B4
-    72, // C5
+const major = [_]u32 {
+    0,
+    2,
+    4,
+    5,
+    7,
+    9,
+    11,
+    12,
 };
-const names: [c_maj.len][:0]const u8 = .{
-    "C4",
-    "D4",
-    "E4",
-    "F4",
-    "G4",
-    "A4",
-    "B4",
-    "C4",
+const note_names_sharps: [12][]const u8 = .{
+    "C",
+    "C#",
+    "D",
+    "D#",
+    "E",
+    "F",
+    "F#",
+    "G",
+    "G#",
+    "A",
+    "A#",
+    "B",
 };
-const freqs = blk: {
-    var fq: [c_maj.len]f32 = undefined;
-    for (&fq, c_maj) |*f, note| {
-        f.* = freqFromMidi(note);
-    }
-    break :blk fq;
+const note_names_flats: [12][]const u8 = .{
+    "C",
+    "Db",
+    "D",
+    "Eb",
+    "E",
+    "F",
+    "Gb",
+    "G",
+    "Ab",
+    "A",
+    "Bb",
+    "B",
+};
+const major_scale_uses_sharps: [12]bool = .{
+    true,  // Techincally C major has neither sharps nor flats
+    false, // Db major, though sometimes C# major
+    true,  // D major
+    false, // Eb major
+    true,  // E major
+    false, // F major
+    false, // Can be either, F# major (#) or Gb major (b)
+    true,  // G major
+    false, // Ab major
+    true,  // A major
+    false, // Bb major
+    true,  // B major
 };
 
-var note_id: u32 = names.len;
+const wave_shapes = [_]cart.Tone2Options.Shape{
+    .square,
+    .triangle,
+    .sawtooth,
+};
+var active_wave_shape: u32 = 0;
+
+var fundamental: u32 = 48;
+var scale_pos: u32 = major.len;
 var global_frame_num: u32 = 0;
 var short: bool = false;
 
@@ -60,6 +95,13 @@ var volume: f32 = 1.0;
 export fn start() void {
     change_time = cart.microsSinceBoot() + micros_per_note;
 }
+
+var was_down = false;
+var was_up = false;
+
+const piano_min_note = 21;
+const piano_max_note = 108;
+const piano_max_fundamental = piano_max_note - 12;
 
 export fn update() void {
     const abs_time = cart.microsSinceBoot();
@@ -80,7 +122,10 @@ export fn update() void {
         //cart.trace("[frame]");
     }
 
+    var note_changed = false;
+
     const controls = cart.controls;
+
     if (controls.left) {
         volume = @max(0.0, volume - delta_sec);
     }
@@ -88,57 +133,183 @@ export fn update() void {
         volume = @min(1.0, volume + delta_sec);
     }
 
+    var selected_param: enum {
+        octave,
+        note,
+        shape,
+    } = .octave;
+
+    if (controls.a) {
+        selected_param = .shape;
+    } else if (controls.b) {
+        selected_param = .note;
+    }
+
+    if (controls.down and !was_down) {
+        switch (selected_param) {
+            .octave => if (fundamental >= piano_min_note + 12) {
+                fundamental -= 12;
+                note_changed = true;
+            },
+            .note => if (fundamental > piano_min_note) {
+                fundamental -= 1;
+                note_changed = true;
+            },
+            .shape => {
+                active_wave_shape += 1;
+                if (active_wave_shape >= wave_shapes.len) {
+                    active_wave_shape = 0;
+                }
+                note_changed = true;
+            },
+        }
+        
+    }
+    if (controls.up and !was_up) {
+        switch (selected_param) {
+            .octave => if (fundamental <= piano_max_fundamental - 12) {
+                fundamental += 12;
+                note_changed = true;
+            },
+            .note => if (fundamental < piano_max_fundamental) {
+                fundamental += 1;
+                note_changed = true;
+            },
+            .shape => {
+                if (active_wave_shape == 0) {
+                    active_wave_shape = wave_shapes.len;
+                }
+                active_wave_shape -= 1;
+                note_changed = true;
+            }
+        }
+    }
+    was_down = controls.down;
+    was_up = controls.up;
+
     if (controls.left or controls.right) {
         cart.setGlobalVolume(volume);
     }
 
-    if (abs_time >= change_time) {
+    if (abs_time >= change_time or note_changed) {
         while (abs_time >= change_time) {
             change_time += micros_per_note;
-            if (note_id >= c_maj.len) {
-                note_id = 0;
+            if (scale_pos >= major.len) {
+                scale_pos = 0;
                 short = !short;
             } else {
-                note_id += 1;
+                scale_pos += 1;
             }
         }
 
-        if (note_id >= c_maj.len) {
+        if (scale_pos >= major.len) {
             cart.tone2(.stop);
         } else {
             cart.tone2(.{
-                .frequency = freqs[note_id],
+                .frequency = freqFromMidi(@floatFromInt(fundamental + major[scale_pos])),
                 .volume = 1.0,
                 .duration = if (short) 0.25 else -1.0,
+                .flags = .{ .shape = wave_shapes[active_wave_shape] },
             });
         }
     }
 
-    const text = if (note_id >= c_maj.len)
-        ""
-    else names[note_id];
+    const note_names = if (major_scale_uses_sharps[fundamental % 12])
+        note_names_sharps
+    else note_names_flats;
+
+    const scale_name = note_names[fundamental % 12];
+
+    var buf: [20]u8 = undefined;
+
+    const volume_top = HH-10;
+    const volume_bot = volume_top + 20;
+    const vol_width = 12*8 + 2*8;
+
+    // Clear behind the scale name
+    const max_scale_width = 10*8;
+    cart.rect(.{
+        .x = HW - max_scale_width/2,
+        .y = volume_top - 10,
+        .width = max_scale_width,
+        .height = 8,
+        .fill_color = gray,
+    });
+
+    // Then draw the scale name
+    const text = std.fmt.bufPrint(&buf, "{s}{d} major", .{scale_name, fundamental / 12 - 1})
+        catch "Err";
+    var x_pos: u16 = @intCast(HW - text.len * 4);
+    cart.text(.{
+        .str = text[0..scale_name.len],
+        .x = x_pos,
+        .y = volume_top - 10,
+        .text_color = if (selected_param == .note) yellow else white,
+    });
+    x_pos += @intCast(8*scale_name.len);
+    cart.text(.{
+        .str = text[scale_name.len..][0..2],
+        .x = x_pos,
+        .y = volume_top - 10,
+        .text_color = if (selected_param == .octave) yellow else white,
+    });
+    x_pos += 8*2;
+    cart.text(.{
+        .str = text[scale_name.len+2..],
+        .x = x_pos,
+        .y = volume_top - 10,
+        .text_color = white,
+    });
 
     // Clear the center of the screen with a white rect
     cart.rect(.{
-        .x = HW-34,
-        .y = HH-10,
-        .width = 34*2,
+        .x = HW-vol_width/2 - 2,
+        .y = volume_top,
+        .width = vol_width + 4,
         .height = 20,
         .fill_color = white,
     });
     // Draw the volume slider
     cart.rect(.{
-        .x = HW-32,
+        .x = HW-vol_width/2,
         .y = HH-8,
-        .width = @intFromFloat(volume * 32 * 2 + 0.5),
+        .width = @intFromFloat(volume * @as(comptime_float, vol_width) + 0.5),
         .height = 16,
         .fill_color = lt_blue,
     });
-    // Draw the text
+
+    // Draw the note name and frequency
+    if (scale_pos < major.len) {
+        const midi_note = fundamental + major[scale_pos];
+        const freq = freqFromMidi(@floatFromInt(midi_note));
+        const name = note_names[midi_note % 12];
+        const note_text = std.fmt.bufPrint(&buf, "{s}{d} {d:5.1}Hz", .{ name, midi_note / 12 - 1, freq })
+            catch "Err";
+        // Draw the text
+        cart.text(.{
+            .str = note_text,
+            .x = @intCast(HW-4*note_text.len),
+            .y = HH-4,
+            .text_color = black,
+        });
+    }
+
+    // Clear behind the wave shape
+    cart.rect(.{
+        .x = HW - max_scale_width/2,
+        .y = volume_bot + 2,
+        .width = max_scale_width,
+        .height = 8,
+        .fill_color = gray,
+    });
+
+    // Draw the wave shape
+    const wave_name = std.fmt.bufPrint(&buf, ".{s}", .{ @tagName(wave_shapes[active_wave_shape]) })
+        catch "Err";
     cart.text(.{
-        .str = text,
-        .x = HW-8,
-        .y = HH-4,
-        .text_color = black,
+        .str = wave_name,
+        .x = @intCast(HW - wave_name.len * 4),
+        .y = volume_bot + 2,
+        .text_color = if (selected_param == .shape) yellow else white,
     });
 }

--- a/src/os/cart/api.zig
+++ b/src/os/cart/api.zig
@@ -737,16 +737,16 @@ pub const Tone2Options = struct {
     // Use this value to stop playing audio
     pub const stop: Tone2Options = .{ .frequency = 0.0 };
 
-    pub const Flags = packed struct(u32) {
-        pub const Shape = enum(u3) {
-            square,   // ---___---___, flute-ish
-            triangle, // /\/\/\/\, string-ish
-            sawtooth, // |\|\|\|\
-            sine, // u^u^u^
-            major, // Major chord with frequency as the fundamental
-            minor, // Minor chord with frequency as the fundamental
-        };
+    pub const Shape = enum(u3) {
+        square,   // ---___---___, clarinet-ish
+        triangle, // /\/\/\/\, flute-ish
+        sawtooth, // |\|\|\|\, violin-ish
+        sine, // u^u^u^
+        major, // Major chord with frequency as the fundamental
+        minor, // Minor chord with frequency as the fundamental
+    };
 
+    pub const Flags = packed struct(u32) {
         /// Type of wave to play
         shape: Shape = .square,
         padding: u29 = undefined,

--- a/src/os/drivers/audio.zig
+++ b/src/os/drivers/audio.zig
@@ -20,6 +20,11 @@ const interrupt = microzig.interrupt;
 const std = @import("std");
 
 const timer = @import("timer.zig");
+const fps_overlay = @import("../system/fps_overlay.zig");
+
+// Aliases for the DMA control registers to avoid triggering DMA start.
+const DMA_CH1_AL1_CTRL: *volatile @TypeOf(DMA.CH1_CTRL_TRIG) = @ptrCast(&DMA.CH1_AL1_CTRL);
+const DMA_CH2_AL1_CTRL: *volatile @TypeOf(DMA.CH2_CTRL_TRIG) = @ptrCast(&DMA.CH2_AL1_CTRL);
 
 /// System clock in Hz (125 MHz for RP2354B)
 /// TODO: This isn't quite right, the notes come out
@@ -44,24 +49,132 @@ const buzzer_pwm_ch = pwm.Pwm{ .slice_number = @intFromEnum(buzzer_pwm_slice), .
 /// Separate PWM slice used for wave timing control
 const audio_timing_slice: pwm.Slice = @enumFromInt(5);
 
-var global_volume: f32 = 1.0;
+/// Global volume setting on reset
+/// 1.0 is quite loud, we might want to reduce this to 0.5 by default
+/// and let users turn it up, maybe by having the cart API allow volume
+/// levels 0-2.
+const initial_global_volume = 1.0;
+
+var global_volume: f32 = initial_global_volume;
+var tone_volume: f32 = 1.0;
+var vol_amplitude: f32 = calc_perceptually_linear_amplitude_for_volume(initial_global_volume);
 
 var sound_type: enum {
     off,
     square,
+    triangle,
+    sawtooth,
+    sample,
 } = .off;
 
-var tone_volume: f32 = 0.0;
+var mix_idx: u32 = 0;
+var mix_ready: u32 = 0;
+var mix_enabled: bool = false;
+var mix_request_time: [2]u64 = .{ 0, 0 };
+var mix_slow: bool = false;
 
-pub fn interrupt_DMA_0(int_bits: u32) u32 {
+fn encode_sample(val: f32) u32 {
+    const val01 = @max(0.0, @min(1.0, val * 0.5 + 0.5));
+    return @as(u32, @intFromFloat(val01 * audio_levels)) << 16;
+}
+
+var period_per_sample: f32 = 0;
+var phase: f32 = 0;
+fn mix_audio_sawtooth(noalias buf: []u32) void {
+    for (buf, 0..) |*sample, i| {
+        const f: f32 = @floatFromInt(i);
+        const samp_phase = phase + period_per_sample * f;
+        const value = (samp_phase - @trunc(samp_phase)) * 2.0 - 1.0;
+        const vol_adj = value * vol_amplitude;
+        sample.* = encode_sample(vol_adj);
+    }
+    phase += @as(f32, @floatFromInt(buf.len)) * period_per_sample;
+    phase = phase - @trunc(phase);
+}
+
+fn mix_audio_triangle(noalias buf: []u32) void {
+    for (buf, 0..) |*sample, i| {
+        const f: f32 = @floatFromInt(i);
+        const samp_phase = phase + period_per_sample * f;
+        const saw_val = (samp_phase - @trunc(samp_phase)) * 2.0 - 1.0;
+        const tri_val = @abs(saw_val) * 2.0 - 1.0;
+        const vol_adj = tri_val * vol_amplitude;
+        sample.* = encode_sample(vol_adj);
+    }
+    phase += @as(f32, @floatFromInt(buf.len)) * period_per_sample;
+    phase = phase - @trunc(phase);
+}
+
+var mixes_remaining: ?u32 = 0;
+var final_mix_samples: u32 = 0;
+fn mix_buffer(buffer: *align(64) [dma_buf_size]u32) bool {
+    const samples_to_mix = if (mixes_remaining) |*rem| blk: {
+        if (rem.* > 1) {
+            rem.* -= 1;
+            break :blk dma_buf_size;
+        } else if (rem.* == 1) {
+            rem.* = 0;
+            break :blk final_mix_samples;
+        } else {
+            @memset(buffer, comptime encode_sample(0.0));
+            return false;
+        }
+    } else dma_buf_size;
+
+    switch (sound_type) {
+        .off, .square => {}, // mixer shouldn't be in use
+        .sawtooth => mix_audio_sawtooth(buffer[0..samples_to_mix]),
+        .triangle => mix_audio_triangle(buffer[0..samples_to_mix]),
+        .sample => {
+            // TODO sample mixing
+        },
+    }
+
+    if (samples_to_mix < dma_buf_size) {
+        @memset(buffer[samples_to_mix..], comptime encode_sample(0.0));
+        return false;
+    }
+
+    return true;
+}
+
+const INTS = &DMA.INTS1;
+const INTE = &DMA.INTE1;
+
+pub fn interrupt_DMA_1() callconv(.c) void {
+    const int_bits = INTS.raw;
     var handled_bits: u32 = 0;
-    _ = int_bits;
-    _ = &handled_bits;
-    return handled_bits;
+
+    if (int_bits & 0b010 != 0) {
+        handled_bits |= 0b010;
+        mix_ready |= 0b010;
+        mix_request_time[0] = timer.micros();
+        // Detect slow mixing
+        if (mix_idx != 1) {
+            mix_slow |= mix_enabled;
+        }
+    }
+
+    if (int_bits & 0b100 != 0) {
+        handled_bits |= 0b100;
+        mix_ready |= 0b100;
+        mix_request_time[1] = timer.micros();
+        // Detect slow mixing
+        if (mix_idx != 0) {
+            mix_slow |= mix_enabled;
+        }
+    }
+
+    INTS.write_raw(handled_bits);
 }
 
 // Needs to be aligned for DMA source
 var square_cc_vals: [2]u32 align(8) = undefined;
+const square_wave_sample: AudioSample = .{
+    .samples_per_fundamental = 2,
+    .wrap_values_bits = 1,
+    .sample_buf = &square_cc_vals,
+};
 
 /// Initialise buzzer hardware.
 /// SPKR_EN is driven low (muted), the PWM pin is muxed to PWM function.
@@ -80,43 +193,65 @@ pub fn init() void {
     buzzer_pwm_ch.set_level(0);
 }
 
-pub fn setGlobalVolume(in_vol: f32) void {
+pub fn set_global_volume(in_vol: f32) void {
     const vol = @max(0.0, @min(1.0, in_vol));
     if (global_volume != vol) {
         global_volume = vol;
-        switch (sound_type) {
-            .off => {},
-            .square => {
-                updateSquareWaveLevels();
-            },
+        update_derived_volume();
+
+        if (sound_type == .square) {
+            update_square_wave_levels();
+        }
+
+        if (sound_type != .off) {
+            board.buzzer_enable.put(@intFromBool(global_volume != 0.0));
         }
     }
 }
 
 pub fn poll() void {
-    // Leaving this stub for future polling needs
+    // Check if a buffer needs mixing
+    if (mix_enabled) {
+        const buffer_bit: u32 = @as(u32, 1) << @intCast(mix_idx + 1);
+        if (mix_ready & buffer_bit != 0) {
+            mix_ready &= ~buffer_bit;
+            const start = timer.micros();
+            const more_buffers = mix_buffer(&audio_dma_buf[mix_idx]);
+            std.mem.doNotOptimizeAway(&audio_dma_buf[mix_idx]);
+            if (!more_buffers) {
+                // Turn off the continuation after the mixed buffer
+                switch(mix_idx) {
+                    0 => DMA.CH2_CTRL_TRIG.modify(.{ .EN = 0 }),
+                    1 => DMA.CH1_CTRL_TRIG.modify(.{ .EN = 0 }),
+                    else => unreachable,
+                }
+            }
+            const end = timer.micros();
+            fps_overlay.submit_audio_mix_time(start, end, mix_request_time[mix_idx]);
+            mix_request_time[mix_idx] = 0;
+            mix_idx = 1 - mix_idx;
+        }
+    }
 }
 
-/// Enable or disable the speaker amplifier without changing the PWM output.
-fn setEnable(enabled: bool) void {
-    board.buzzer_enable.put(@intFromBool(enabled));
-}
-
-fn calcPerceptuallyLinearAmplitudeScaleForVolume(volume: f32) f32 {
+fn calc_perceptually_linear_amplitude_for_volume(volume: f32) f32 {
     // Adjust the volume on a log scale for perceptual linearity
     // Total range of 50 dB between min and max volume
+    const clipped_vol = @max(0.0, @min(1.0, volume));
     const db_range = -50.0;
     const exp_range = db_range / 20.0 * @log(10.0);
-    const vol_adjust_exp = exp_range * (1.0 - volume);
+    const vol_adjust_exp = exp_range * (1.0 - clipped_vol);
     return @exp(vol_adjust_exp);
 }
 
-fn updateSquareWaveLevels() void {
+fn update_derived_volume() void {
     const volume = global_volume * tone_volume;
-    const vol_amplitude = calcPerceptuallyLinearAmplitudeScaleForVolume(volume);
+    vol_amplitude = calc_perceptually_linear_amplitude_for_volume(volume);
+}
 
+fn update_square_wave_levels() void {
     const midpoint = @as(f32, @floatFromInt(audio_levels)) / 2;
-    const amplitude = midpoint * vol_amplitude; // exp scale is more accurate but sq works for now.
+    const amplitude = midpoint * vol_amplitude;
 
     // Square wave
     // Use round and floor to allow amplitudes with an odd number of divisions
@@ -129,39 +264,94 @@ fn updateSquareWaveLevels() void {
 /// Start a continuous tone at `freq_hz`.
 /// Passing 0 is equivalent to calling `stop()`.
 /// The speaker enable pin is asserted automatically.
-pub fn tone(freq_hz: f32, duration_sec: f32, volume: f32) void {
+pub fn tone(freq_hz: f32, duration_sec: f32, volume: f32, flags: u32) void {
+    board.led_pin.put(0);
+
     if (freq_hz == 0 or volume <= 0 or (duration_sec != -1.0 and duration_sec <= 0.0)) {
         stop();
         return;
     }
 
-    beginStopDma();
+    begin_stop_DMA();
 
-    tone_volume = volume;
-    updateSquareWaveLevels();
+    if (volume != tone_volume) {
+        tone_volume = volume;
+        update_derived_volume();
+    }
 
+    const sample_sel = flags & 0x7;
+
+    switch (sample_sel) {
+        0 => {
+            update_square_wave_levels();
+            setup_audio_sample_DMA(duration_sec, freq_hz, square_wave_sample) catch {
+                // This frequency is too slow for us to reproduce, and also probably
+                // too slow to hear, so just stop audio.
+                stop();
+                return;
+            };
+        },
+        else => {
+            const sample_freq = @as(comptime_float, audio_levels) * freq_hz;
+            const max_freq = 44100.0 / 2.0;
+            if (sample_freq <= max_freq) {
+                period_per_sample = 1.0 / @as(comptime_float, audio_levels);
+                setup_ping_pong_DMA(duration_sec, sample_freq) catch {
+                    stop();
+                    return;
+                };
+            } else {
+                // Too fast, slow it down!
+                period_per_sample = freq_hz / max_freq;
+                setup_ping_pong_DMA(duration_sec, max_freq) catch unreachable;
+            }
+            sound_type = switch (sample_sel) {
+                1 => .triangle,
+                2 => .sawtooth,
+                else => { stop(); return; }
+            };
+        },
+    }
+
+    // Then came. The Noise.
+    audio_timing_slice.enable();
+    buzzer_pwm_slice.enable();
+
+    // When the volume is 0, we still need to enable the
+    // PWM slices, mixer, etc, because the volume may change
+    // while the tone is playing and we need it to start
+    // running. However, we turn off the buzzer enable at 0
+    // to ensure no sound comes out.
+    // set_global_volume() has more handling of this case.
+    if (global_volume != 0.0) {
+        board.buzzer_enable.put(1);
+    }
+}
+
+const AudioSample = struct {
+    samples_per_fundamental: f32,
+    wrap_values_bits: u32,
+    sample_buf: [*]const u32,
+};
+
+fn set_timing_PWM_hz(hz: f32) !void {
     // A piano ranges from 27.5 Hz to 4186 Hz, so for the square wave generator
     // clock we need to support a pretty wide range with reasonable accuracy.
     // The possible source clocks are 8.4 fractional divs of the sys clock,
     // or 0 for a max div of 256
 
-    // We need to trigger DMA twice per wavelength
-    const trig_hz = freq_hz * 2.0;
-
     const clk_rate = @as(f32, @floatFromInt(buzzer_sys_clk_hz));
-    var clk_div = @ceil(clk_rate * 16.0 / 65536.0 / trig_hz);
+    var clk_div = @ceil(clk_rate * 16.0 / 65536.0 / hz);
 
     // Can't divide by less than 1.0
     clk_div = @max(16.0, clk_div);
 
     if (clk_div > (1<<13)) {
-        // This frequency is too slow for us to reproduce, and also probably
-        // too slow to hear, so just stop audio.
-        stop();
-        return;
+        // The target frequency is too slow to reproduce
+        return error.FrequencyTooSlow;
     }
 
-    var wrap_ticks = clk_rate * 16.0 / clk_div / trig_hz;
+    var wrap_ticks = clk_rate * 16.0 / clk_div / hz;
 
     // Centered mode allows another 2x divider on the clock
     var use_centered_mode = false;
@@ -178,14 +368,23 @@ pub fn tone(freq_hz: f32, duration_sec: f32, volume: f32) void {
     audio_timing_slice.set_phase_correct(use_centered_mode);
     audio_timing_slice.set_clk_div(@intCast(clk_div_int >> 4), @intCast(clk_div_int & 0xF));
     audio_timing_slice.set_wrap(@intCast(wrap_int));
+}
 
-    finishStopDma();
+fn setup_audio_sample_DMA(duration_sec: f32, frequency: f32, sample: AudioSample) !void {
+    const sample_hz = frequency * sample.samples_per_fundamental;
+
+    try set_timing_PWM_hz(sample_hz);
+
+    finish_stop_DMA();
+
+    // Disable DMA interrupts
+    INTE.write_raw(INTE.raw & ~@as(u32, 0b110));
 
     // Configure DMA ch1 to update the duty cycle
     // for pin 9 every time the timing slice wraps,
     // switching between the low part and the high
     // part of the square wave.
-    DMA.CH1_READ_ADDR.write(.{ .CH1_READ_ADDR = @intFromPtr(&square_cc_vals) });
+    DMA.CH1_READ_ADDR.write(.{ .CH1_READ_ADDR = @intFromPtr(sample.sample_buf) });
     // TODO get_registers() doesn't exist until future versions
     //DMA.CH1_WRITE_ADDR.write(.{ .CH1_WRITE_ADDR = @intFromPtr(&buzzer_pwm_slice.get_registers().cc) });
     DMA.CH1_WRITE_ADDR.write(.{ .CH1_WRITE_ADDR = @intFromPtr(&PWM.CH4_CC) });
@@ -195,7 +394,7 @@ pub fn tone(freq_hz: f32, duration_sec: f32, volume: f32) void {
             .COUNT = 1,
         });
     } else {
-        const dma_count: u32 = @intFromFloat(@round(duration_sec * trig_hz));
+        const dma_count: u32 = @intFromFloat(@round(duration_sec * sample_hz));
         DMA.CH1_TRANS_COUNT.write(.{
             .MODE = .NORMAL, // Count down and stop
             .COUNT = @intCast(dma_count),
@@ -210,7 +409,75 @@ pub fn tone(freq_hz: f32, duration_sec: f32, volume: f32) void {
         .TREQ_SEL = @as(TreqEnum, @enumFromInt(@intFromEnum(TreqEnum.pwm_wrap0) + @intFromEnum(audio_timing_slice))),
         .CHAIN_TO = 1, // Chain to self, meaning disable
         .RING_SEL = 0, // Wrap reads
-        .RING_SIZE = @as(RingEnum, @enumFromInt(3)), // Wrap every 2 values / 8 bytes
+        .RING_SIZE = @as(RingEnum, @enumFromInt(sample.wrap_values_bits + 2)), // Wrap every 2 values / 8 bytes
+        .INCR_WRITE_REV = 0,
+        .INCR_WRITE = 0,
+        .INCR_READ_REV = 0,
+        .INCR_READ = 1, // Increment read address
+        .DATA_SIZE = .size_32,
+        .HIGH_PRIORITY = 1, // Audio is high priority, delays are audible
+        .EN = 1,
+    });
+}
+
+fn setup_ping_pong_DMA(duration_sec: f32, sample_freq: f32) !void {
+    try set_timing_PWM_hz(sample_freq);
+
+    finish_stop_DMA();
+
+    if (duration_sec >= 0) {
+        // This can be large enough that we lose precision.
+        // The following operations are designed to keep as
+        // much precision as possible without using more than
+        // 32 bits.
+        const total_samples_flt = @as(f64, duration_sec) * @as(f64, sample_freq);
+        const total_samples_64: u64 = @intFromFloat(total_samples_flt);
+        const total_mixes_64 = (total_samples_64 + dma_buf_size - 1) / dma_buf_size;
+        const final_samples: u32 = @intCast(total_samples_64 % dma_buf_size);
+        // If the number of mixes overflows a u32, that's hundreds of days.
+        // Just call it infinite at that point.
+        mixes_remaining = if (total_mixes_64 > ~@as(u32, 0)) null else @intCast(total_mixes_64);
+        final_mix_samples = if (final_samples == 0) dma_buf_size else final_samples;
+    } else {
+        mixes_remaining = null;
+        final_mix_samples = dma_buf_size;
+    }
+
+    // Clear and enable DMA interrupts
+    INTS.write_raw(0b110);
+    INTE.write_raw(INTE.raw | 0b110);
+
+    // For simplicty, don't handle very short audio spurts here.
+    _ = mix_buffer(&audio_dma_buf[0]);
+    _ = mix_buffer(&audio_dma_buf[1]);
+    mix_idx = 0;
+    mix_enabled = true;
+
+    // Configure DMA ch1 to update the duty cycle
+    // for pin 9 every time the timing slice wraps,
+    // switching between the low part and the high
+    // part of the square wave.
+    DMA.CH1_READ_ADDR.write(.{ .CH1_READ_ADDR = @intFromPtr(&audio_dma_buf[0]) });
+    DMA.CH2_READ_ADDR.write(.{ .CH2_READ_ADDR = @intFromPtr(&audio_dma_buf[1]) });
+    // TODO get_registers() doesn't exist until future versions
+    //DMA.CH1_WRITE_ADDR.write(.{ .CH1_WRITE_ADDR = @intFromPtr(&buzzer_pwm_slice.get_registers().cc) });
+    //DMA.CH2_WRITE_ADDR.write(.{ .CH2_WRITE_ADDR = @intFromPtr(&buzzer_pwm_slice.get_registers().cc) });
+    DMA.CH1_WRITE_ADDR.write(.{ .CH1_WRITE_ADDR = @intFromPtr(&PWM.CH4_CC) });
+    DMA.CH2_WRITE_ADDR.write(.{ .CH2_WRITE_ADDR = @intFromPtr(&PWM.CH4_CC) });
+    DMA.CH1_TRANS_COUNT.write(.{ .MODE = .NORMAL, .COUNT = audio_dma_buf[0].len });
+    DMA.CH2_TRANS_COUNT.write(.{ .MODE = .NORMAL, .COUNT = audio_dma_buf[1].len });
+    const TreqEnum = @TypeOf(std.mem.zeroes(@TypeOf(DMA.CH1_CTRL_TRIG).underlying_type).TREQ_SEL);
+
+    // Ch2 first since we don't trigger it, then Ch1 to kick things off.
+    const RingEnum2 = @TypeOf(std.mem.zeroes(@TypeOf(DMA.CH2_CTRL_TRIG).underlying_type).RING_SIZE);
+    DMA_CH2_AL1_CTRL.modify(.{
+        .SNIFF_EN = 0,
+        .BSWAP = 0,
+        .IRQ_QUIET = 0,
+        .TREQ_SEL = @as(TreqEnum, @enumFromInt(@intFromEnum(TreqEnum.pwm_wrap0) + @intFromEnum(audio_timing_slice))),
+        .CHAIN_TO = 1, // Chain ping pong to 1
+        .RING_SEL = 0, // Wrap reads
+        .RING_SIZE = @as(RingEnum2, @enumFromInt(log2_dma_buf_size + 2)), // Wrap to restart DMA
         .INCR_WRITE_REV = 0,
         .INCR_WRITE = 0,
         .INCR_READ_REV = 0,
@@ -220,25 +487,43 @@ pub fn tone(freq_hz: f32, duration_sec: f32, volume: f32) void {
         .EN = 1,
     });
 
-    // Then came. The Noise.
-    sound_type = .square;
-    audio_timing_slice.enable();
-    buzzer_pwm_slice.enable();
-    setEnable(true);
+    const RingEnum1 = @TypeOf(std.mem.zeroes(@TypeOf(DMA.CH1_CTRL_TRIG).underlying_type).RING_SIZE);
+    DMA.CH1_CTRL_TRIG.modify(.{
+        .SNIFF_EN = 0,
+        .BSWAP = 0,
+        .IRQ_QUIET = 0,
+        .TREQ_SEL = @as(TreqEnum, @enumFromInt(@intFromEnum(TreqEnum.pwm_wrap0) + @intFromEnum(audio_timing_slice))),
+        .CHAIN_TO = 2, // Chain ping pong to 2
+        .RING_SEL = 0, // Wrap reads
+        .RING_SIZE = @as(RingEnum1, @enumFromInt(log2_dma_buf_size + 2)), // Wrap to restart DMA
+        .INCR_WRITE_REV = 0,
+        .INCR_WRITE = 0,
+        .INCR_READ_REV = 0,
+        .INCR_READ = 1, // Increment read address
+        .DATA_SIZE = .size_32,
+        .HIGH_PRIORITY = 1, // Audio is high priority, delays are audible
+        .EN = 1,
+    });
 }
 
-fn beginStopDma() void {
-    DMA.CHAN_ABORT.write(.{ .CHAN_ABORT = 0b10 });
+fn begin_stop_DMA() void {
+    mix_enabled = false;
+    DMA.CH1_CTRL_TRIG.modify(.{ .EN = 0 });
+    DMA.CH2_CTRL_TRIG.modify(.{ .EN = 0 });
+    DMA.CHAN_ABORT.write(.{ .CHAN_ABORT = 0b110 });
 }
 
-fn finishStopDma() void {
-    while (DMA.CH1_CTRL_TRIG.read().BUSY != 0) {}
+fn finish_stop_DMA() void {
+    while (DMA.CHAN_ABORT.raw & 0b110 != 0b110) {
+        DMA.CHAN_ABORT.write_raw(0b110);
+    }
+    mix_ready = 0;
 }
 
 /// Stop PWM output and deassert SPKR_EN.
 pub fn stop() void {
-    setEnable(false);
-    beginStopDma();
+    board.buzzer_enable.put(0);
+    begin_stop_DMA();
     buzzer_pwm_slice.disable();
     audio_timing_slice.disable();
     board.buzzer_pwm.put(0);
@@ -248,5 +533,11 @@ pub fn stop() void {
 /// Reset the audio module for a new cart
 pub fn reset() void {
     stop();
-    global_volume = 1.0;
+    global_volume = initial_global_volume;
+    tone_volume = 1.0;
+    vol_amplitude = comptime calc_perceptually_linear_amplitude_for_volume(initial_global_volume);
 }
+
+const log2_dma_buf_size: u32 = 9; // 512 samples, about 12 mS of audio at 44.1kHz
+const dma_buf_size: u32 = 1 << log2_dma_buf_size;
+var audio_dma_buf: [2][dma_buf_size]u32 align(dma_buf_size * @sizeOf(u32)) = undefined;

--- a/src/os/drivers/lcd.zig
+++ b/src/os/drivers/lcd.zig
@@ -813,8 +813,8 @@ pub fn writeCartBufferRect(buffer: []const u16, x: u16, y: u16, w: u16, h: u16) 
     writeCommandWithData(.MADCTL, &.{0x40});
 
     // In this mode, cart x maps to native row and cart y maps to native col (reversed).
-    const col_start: u16 = 127 - y1;
-    const col_end: u16 = 127 - y0;
+    const col_start: u16 = y0;
+    const col_end: u16 = y1;
     const row_start: u16 = x0;
     const row_end: u16 = x1;
 

--- a/src/os/interrupts.zig
+++ b/src/os/interrupts.zig
@@ -10,8 +10,10 @@ const lcd = @import("drivers/lcd.zig");
 
 pub const interrupts: microzig.InterruptOptions = .{
     .DMA_IRQ_0 = .{ .c = lcd.interrupt_DMA_0 },
+    .DMA_IRQ_1 = .{ .c = audio.interrupt_DMA_1 },
 };
 
 pub fn init() void {
     int.enable(.DMA_IRQ_0);
+    int.enable(.DMA_IRQ_1);
 }

--- a/src/os/kernel.zig
+++ b/src/os/kernel.zig
@@ -341,10 +341,11 @@ pub fn main() !void {
                     const freq: f32 = mailbox.shared_data.tone_freq;
                     const duration_sec: f32 = mailbox.shared_data.tone_duration;
                     const volume = mailbox.shared_data.tone_volume;
-                    audio.tone(freq, duration_sec, volume);
+                    const flags = mailbox.shared_data.tone_flags;
+                    audio.tone(freq, duration_sec, volume, flags);
                 } else if (mailbox.MessageType.getType(msg) == mailbox.MessageType.CART_VOLUME) {
                     const volume = mailbox.shared_data.global_volume;
-                    audio.setGlobalVolume(volume);
+                    audio.set_global_volume(volume);
                 } else if (msg == mailbox.MessageType.FRAMEBUFFER_READY or
                     mailbox.MessageType.getType(msg) == mailbox.MessageType.FRAMEBUFFER_READY_V2)
                 {

--- a/src/os/loader/storage.zig
+++ b/src/os/loader/storage.zig
@@ -48,6 +48,10 @@ var pending_valid: bool = false;
 var pending_dirty: bool = false;
 var pending_buf: [FLASH_ERASE_BLOCK]u8 align(4) = undefined;
 
+// These arrays are too large to put on the stack, so we
+// reuse them carefully throughout the functions in this file.
+var sector_bufs: [2][SECTOR_SIZE]u8 = undefined;
+
 pub var formatted_this_boot: bool = false;
 
 pub fn init() void {
@@ -129,7 +133,7 @@ pub fn getStats() StorageStats {
     var used: u16 = 0;
     var cluster: u16 = 2;
     while (cluster < stats.total_clusters + 2) : (cluster += 1) {
-        const entry = fatEntry(cluster);
+        const entry = fatEntry(cluster, &sector_bufs[0], &sector_bufs[1]);
         if (entry != 0) {
             used += 1;
         }
@@ -139,13 +143,13 @@ pub fn getStats() StorageStats {
     stats.free_space_bytes = @as(u32, stats.free_clusters) * SECTORS_PER_CLUSTER * SECTOR_SIZE;
 
     // Count root directory entries
-    var sector_buf: [SECTOR_SIZE]u8 = undefined;
     const root_start = VOLUME_START_LBA + RESERVED_SECTORS + (@as(u32, NUM_FATS) * fat_secs);
     var lba: u32 = root_start;
     var remaining: u16 = root_secs;
     var used_entries: u16 = 0;
     var deleted_entries: u16 = 0;
     var file_count: u16 = 0;
+    const sector_buf = &sector_bufs[0];
 
     while (remaining > 0) : ({
         lba += 1;
@@ -219,30 +223,29 @@ fn dataStartLba() u32 {
 
 fn isFormatted() bool {
     // Use readSector() instead of direct flash access to ensure we see any pending/buffered data
-    var boot: [SECTOR_SIZE]u8 = undefined;
-    readSector(0, boot[0..]);
+    var sector_buf = &sector_bufs[0];
+    readSector(0, sector_buf[0..]); // boot sector
 
-    const signature = readU16(boot[0..], BS_SIGNATURE);
-    const bytes_per_sector = readU16(boot[0..], BS_BYTES_PER_SECTOR);
-    const root_entries = readU16(boot[0..], 17);
-    const fs_type = boot[BS_FS_TYPE .. BS_FS_TYPE + 8];
+    const signature = readU16(sector_buf[0..], BS_SIGNATURE);
+    const bytes_per_sector = readU16(sector_buf[0..], BS_BYTES_PER_SECTOR);
+    const root_entries = readU16(sector_buf[0..], 17);
+    const fs_type = sector_buf[BS_FS_TYPE .. BS_FS_TYPE + 8];
 
     // Check all BPB fields match expected values
     if (signature != 0xAA55 or bytes_per_sector != SECTOR_SIZE or root_entries != ROOT_ENTRIES or !std.mem.eql(u8, fs_type, "FAT12   ")) {
         return false;
     }
-    var fat0: [SECTOR_SIZE]u8 = undefined;
-    readSector(1, fat0[0..]);
-    const valid = fat0[0] == MEDIA_DESCRIPTOR and fat0[1] == 0xFF and fat0[2] == 0xFF and fat0[3] == 0xFF;
+    readSector(1, sector_buf[0..]); // fat0 sector
+    const valid = sector_buf[0] == MEDIA_DESCRIPTOR and sector_buf[1] == 0xFF and sector_buf[2] == 0xFF and sector_buf[3] & 0xF == 0xF;
     return valid;
 }
 
 /// Check if the stored filesystem size matches current expected size
 fn isSizeCorrect() bool {
-    var boot: [SECTOR_SIZE]u8 = undefined;
-    readSector(0, boot[0..]);
+    var sector_buf = &sector_bufs[0];
+    readSector(0, sector_buf[0..]); // boot sector
 
-    const stored_total = readU16(boot[0..], 19); // Total sectors (16-bit)
+    const stored_total = readU16(sector_buf[0..], 19); // Total sectors (16-bit)
     const expected_total: u16 = @intCast(volumeTotalSectors());
 
     return stored_total == expected_total;
@@ -250,40 +253,41 @@ fn isSizeCorrect() bool {
 
 fn formatVolume() void {
     const volume_sectors = volumeTotalSectors();
-    var boot_sector: [SECTOR_SIZE]u8 = [_]u8{0} ** SECTOR_SIZE;
-    boot_sector[0] = 0xEB;
-    boot_sector[1] = 0x3C;
-    boot_sector[2] = 0x90;
-    @memcpy(boot_sector[3..11], "SYCLBADG");
-    writeU16(boot_sector[0..], BS_BYTES_PER_SECTOR, @intCast(SECTOR_SIZE));
-    boot_sector[13] = SECTORS_PER_CLUSTER;
-    writeU16(boot_sector[0..], 14, RESERVED_SECTORS);
-    boot_sector[16] = NUM_FATS;
-    writeU16(boot_sector[0..], 17, ROOT_ENTRIES);
-    writeU16(boot_sector[0..], 19, @intCast(volume_sectors));
-    boot_sector[21] = MEDIA_DESCRIPTOR;
-    writeU16(boot_sector[0..], 22, fatSectors());
-    writeU16(boot_sector[0..], 24, 32);
-    writeU16(boot_sector[0..], 26, 64);
-    writeU32(boot_sector[0..], 28, 0);
-    writeU32(boot_sector[0..], 32, 0);
-    boot_sector[36] = 0x80;
-    boot_sector[38] = 0x29;
-    writeU32(boot_sector[0..], 39, 0x20260120);
-    @memcpy(boot_sector[43..54], "SYCLBADGE  ");
-    @memcpy(boot_sector[BS_FS_TYPE .. BS_FS_TYPE + 8], "FAT12   ");
-    writeU16(boot_sector[0..], BS_SIGNATURE, 0xAA55);
+    {
+        const boot_sector = &sector_bufs[0];
+        @memset(boot_sector, 0);
 
-    writeSector(0, boot_sector[0..]);
+        boot_sector[0] = 0xEB;
+        boot_sector[1] = 0x3C;
+        boot_sector[2] = 0x90;
+        @memcpy(boot_sector[3..11], "SYCLBADG");
+        writeU16(boot_sector[0..], BS_BYTES_PER_SECTOR, @intCast(SECTOR_SIZE));
+        boot_sector[13] = SECTORS_PER_CLUSTER;
+        writeU16(boot_sector[0..], 14, RESERVED_SECTORS);
+        boot_sector[16] = NUM_FATS;
+        writeU16(boot_sector[0..], 17, ROOT_ENTRIES);
+        writeU16(boot_sector[0..], 19, @intCast(volume_sectors));
+        boot_sector[21] = MEDIA_DESCRIPTOR;
+        writeU16(boot_sector[0..], 22, fatSectors());
+        writeU16(boot_sector[0..], 24, 32);
+        writeU16(boot_sector[0..], 26, 64);
+        writeU32(boot_sector[0..], 28, 0);
+        writeU32(boot_sector[0..], 32, 0);
+        boot_sector[36] = 0x80;
+        boot_sector[38] = 0x29;
+        writeU32(boot_sector[0..], 39, 0x20260120);
+        @memcpy(boot_sector[43..54], "SYCLBADGE  ");
+        @memcpy(boot_sector[BS_FS_TYPE .. BS_FS_TYPE + 8], "FAT12   ");
+        writeU16(boot_sector[0..], BS_SIGNATURE, 0xAA55);
+
+        writeSector(0, boot_sector[0..]);
+    }
+
+    var sector_buf = &sector_bufs[0];
 
     const fat_start = RESERVED_SECTORS;
     const fat_secs = fatSectors();
-    var sector_buf: [SECTOR_SIZE]u8 = [_]u8{0} ** SECTOR_SIZE;
-    sector_buf[0] = MEDIA_DESCRIPTOR;
-    sector_buf[1] = 0xFF;
-    sector_buf[2] = 0xFF;
-    sector_buf[3] = 0xFF;
-
+    @memset(sector_buf[4..], 0);
     var fat_index: u8 = 0;
     while (fat_index < NUM_FATS) : (fat_index += 1) {
         var i: u16 = 0;
@@ -294,28 +298,27 @@ fn formatVolume() void {
                 sector_buf[0] = MEDIA_DESCRIPTOR;
                 sector_buf[1] = 0xFF;
                 sector_buf[2] = 0xFF;
-                sector_buf[3] = 0x00;
+                sector_buf[3] = 0x0F;
             } else {
                 // Subsequent FAT sectors are all zeros
-                @memset(sector_buf[0..], 0);
+                @memset(sector_buf[0..4], 0);
             }
-            writeSector(lba, sector_buf[0..]);
+            writeSector(lba, sector_buf);
         }
     }
 
     const root_lba = fat_start + (@as(u32, NUM_FATS) * fat_secs);
     const root_secs = rootDirSectors();
     var j: u16 = 0;
-    var zero_sector: [SECTOR_SIZE]u8 = [_]u8{0} ** SECTOR_SIZE;
+    @memset(sector_buf, 0);
     while (j < root_secs) : (j += 1) {
-        writeSector(root_lba + j, zero_sector[0..]);
+        writeSector(root_lba + j, sector_buf);
     }
 
     // Write a volume label entry in the first root directory sector.
-    var label_sector: [SECTOR_SIZE]u8 = [_]u8{0} ** SECTOR_SIZE;
-    @memcpy(label_sector[DIR_NAME .. DIR_NAME + 11], "SYCLBADGE  ");
-    label_sector[DIR_ATTR] = 0x08; // Volume label
-    writeSector(root_lba, label_sector[0..]);
+    @memcpy(sector_buf[DIR_NAME .. DIR_NAME + 11], "SYCLBADGE  ");
+    sector_buf[DIR_ATTR] = 0x08; // Volume label
+    writeSector(root_lba, sector_buf[0..]);
     flushPendingWrites();
 
     // Mark formatted and record debug message
@@ -413,8 +416,8 @@ fn flushPending() linksection(".ram_text") void {
 }
 
 pub fn listCarts(callback: *const fn (name: []const u8, size: u32) void) void {
-    var sector_buf: [SECTOR_SIZE]u8 = undefined;
-    var prev_sector_buf: [SECTOR_SIZE]u8 = undefined;
+    var sector_buf = &sector_bufs[0];
+    var prev_sector_buf = &sector_bufs[1];
     const root_start = VOLUME_START_LBA + RESERVED_SECTORS + (@as(u32, NUM_FATS) * fatSectors());
     const root_secs = rootDirSectors();
     var lba: u32 = root_start;
@@ -429,7 +432,9 @@ pub fn listCarts(callback: *const fn (name: []const u8, size: u32) void) void {
     }) {
         // Copy current sector to prev before reading new one
         if (has_prev_sector) {
-            @memcpy(&prev_sector_buf, &sector_buf);
+            const tmp = prev_sector_buf;
+            prev_sector_buf = sector_buf;
+            sector_buf = tmp;
         }
         readSector(lba, sector_buf[0..]);
         has_prev_sector = true;
@@ -445,7 +450,7 @@ pub fn listCarts(callback: *const fn (name: []const u8, size: u32) void) void {
             if (attr & 0x10 != 0) continue; // directory
 
             // Read LFN entries
-            const lfn_len = readLfnEntriesMultiSector(if (lba > root_start) &prev_sector_buf else null, sector_buf[0..], i, lfn_buf[0..]);
+            const lfn_len = readLfnEntriesMultiSector(if (lba > root_start) prev_sector_buf else null, sector_buf[0..], i, lfn_buf[0..]);
             const display_name = if (lfn_len > 0)
                 lfn_buf[0..lfn_len]
             else
@@ -460,8 +465,6 @@ pub fn listCarts(callback: *const fn (name: []const u8, size: u32) void) void {
 /// Count carts in storage and optionally get the first cart's info
 /// Returns: number of carts found, fills in first_cart if count == 1
 pub fn countCarts(first_cart: ?*CartInfo) u32 {
-    var sector_buf: [SECTOR_SIZE]u8 = undefined;
-    var prev_sector_buf: [SECTOR_SIZE]u8 = undefined;
     const root_start = VOLUME_START_LBA + RESERVED_SECTORS + (@as(u32, NUM_FATS) * fatSectors());
     const root_secs = rootDirSectors();
     var lba: u32 = root_start;
@@ -471,6 +474,8 @@ pub fn countCarts(first_cart: ?*CartInfo) u32 {
     var has_prev_sector = false;
     var count: u32 = 0;
     var found_first = false;
+    var prev_sector_buf = &sector_bufs[0];
+    var sector_buf = &sector_bufs[1];
 
     while (remaining > 0) : ({
         lba += 1;
@@ -478,7 +483,9 @@ pub fn countCarts(first_cart: ?*CartInfo) u32 {
     }) {
         // Copy current sector to prev before reading new one
         if (has_prev_sector) {
-            @memcpy(&prev_sector_buf, &sector_buf);
+            const tmp = sector_buf;
+            sector_buf = prev_sector_buf;
+            prev_sector_buf = tmp;
         }
         readSector(lba, sector_buf[0..]);
         has_prev_sector = true;
@@ -521,8 +528,6 @@ pub fn countCarts(first_cart: ?*CartInfo) u32 {
 pub fn findCart(name: []const u8) ?CartInfo {
     var target: [12]u8 = undefined;
     const target_len = normalizeName(name, &target);
-    var sector_buf: [SECTOR_SIZE]u8 = undefined;
-    var prev_sector_buf: [SECTOR_SIZE]u8 = undefined;
     const root_start = VOLUME_START_LBA + RESERVED_SECTORS + (@as(u32, NUM_FATS) * fatSectors());
     const root_secs = rootDirSectors();
     var lba: u32 = root_start;
@@ -530,13 +535,17 @@ pub fn findCart(name: []const u8) ?CartInfo {
     var name_buf: [12]u8 = undefined;
     var lfn_buf: [256]u8 = undefined;
     var has_prev_sector = false;
+    var sector_buf = &sector_bufs[0];
+    var prev_sector_buf = &sector_bufs[1];
 
     while (remaining > 0) : ({
         lba += 1;
         remaining -= 1;
     }) {
         if (has_prev_sector) {
-            @memcpy(&prev_sector_buf, &sector_buf);
+            const tmp = sector_buf;
+            sector_buf = prev_sector_buf;
+            prev_sector_buf = tmp;
         }
         readSector(lba, sector_buf[0..]);
         has_prev_sector = true;
@@ -552,7 +561,7 @@ pub fn findCart(name: []const u8) ?CartInfo {
             if (attr & 0x10 != 0) continue;
 
             // Try to read LFN (may span sectors)
-            const lfn_len = readLfnEntriesMultiSector(if (lba > root_start) &prev_sector_buf else null, sector_buf[0..], i, lfn_buf[0..]);
+            const lfn_len = readLfnEntriesMultiSector(if (lba > root_start) prev_sector_buf else null, sector_buf[0..], i, lfn_buf[0..]);
 
             // Check if name matches LFN (not case-sensitive)
             var matches = false;
@@ -593,8 +602,6 @@ pub fn findCart(name: []const u8) ?CartInfo {
 pub fn deleteCart(name: []const u8) bool {
     var target: [12]u8 = undefined;
     const target_len = normalizeName(name, &target);
-    var sector_buf: [SECTOR_SIZE]u8 = undefined;
-    var prev_sector_buf: [SECTOR_SIZE]u8 = undefined;
     const root_start = VOLUME_START_LBA + RESERVED_SECTORS + (@as(u32, NUM_FATS) * fatSectors());
     const root_secs = rootDirSectors();
     var lba: u32 = root_start;
@@ -602,6 +609,8 @@ pub fn deleteCart(name: []const u8) bool {
     var name_buf: [12]u8 = undefined;
     var lfn_buf: [256]u8 = undefined;
     var has_prev_sector = false;
+    var prev_sector_buf = &sector_bufs[0];
+    var sector_buf = &sector_bufs[1];
 
     while (remaining > 0) : ({
         lba += 1;
@@ -609,7 +618,9 @@ pub fn deleteCart(name: []const u8) bool {
     }) {
         // Keep previous sector for cross-sector LFN deletion
         if (has_prev_sector) {
-            @memcpy(&prev_sector_buf, &sector_buf);
+            const tmp = sector_buf;
+            sector_buf = prev_sector_buf;
+            prev_sector_buf = tmp;
         }
         readSector(lba, sector_buf[0..]);
         has_prev_sector = true;
@@ -625,7 +636,7 @@ pub fn deleteCart(name: []const u8) bool {
             if (attr & 0x10 != 0) continue;
 
             // Use multi-sector LFN reading (matches listCarts/findCart)
-            const lfn_len = readLfnEntriesMultiSector(if (lba > root_start) &prev_sector_buf else null, sector_buf[0..], i, lfn_buf[0..]);
+            const lfn_len = readLfnEntriesMultiSector(if (lba > root_start) prev_sector_buf else null, sector_buf[0..], i, lfn_buf[0..]);
 
             // Check if name matches LFN or SFN
             var matches = false;
@@ -682,8 +693,13 @@ pub fn deleteCart(name: []const u8) bool {
                     }
                 }
 
+                // At this point we no longer need the sector bufs,
+                // reuse them for clearing the FAT chain.
+                sector_buf.* = undefined;
+                prev_sector_buf.* = undefined;
+
                 // Free the FAT chain and flush all writes to flash
-                clearFatChain(start_cluster);
+                clearFatChain(start_cluster, sector_buf, prev_sector_buf);
                 flushPendingWrites();
 
                 // Compact directory to reclaim deleted entry space
@@ -702,7 +718,7 @@ pub fn readCart(cart: CartInfo, dst: []u8) u32 {
     var bytes_left: u32 = cart.size;
     var cluster = cart.start_cluster;
     var dst_offset: usize = 0;
-    var sector_buf: [SECTOR_SIZE]u8 = undefined;
+    const sector_buf = &sector_bufs[0];
 
     while (cluster >= 2 and cluster < 0xFFF8 and bytes_left > 0) {
         var sector_index: u8 = 0;
@@ -714,7 +730,7 @@ pub fn readCart(cart: CartInfo, dst: []u8) u32 {
             bytes_left -= @intCast(copy_len);
             dst_offset += copy_len;
         }
-        cluster = fatEntry(cluster);
+        cluster = fatEntry(cluster, sector_buf, &sector_bufs[1]);
     }
     return @intCast(dst_offset);
 }
@@ -723,19 +739,17 @@ fn clusterToLba(cluster: u16) u32 {
     return dataStartLba() + (@as(u32, cluster - 2) * SECTORS_PER_CLUSTER);
 }
 
-fn fatEntry(cluster: u16) u16 {
+fn fatEntry(cluster: u16, sector_buf: *[SECTOR_SIZE]u8, next_buf: *[SECTOR_SIZE]u8) u16 {
     const fat_start = VOLUME_START_LBA + RESERVED_SECTORS;
     const offset = @as(u32, cluster) + (@as(u32, cluster) / 2);
     const lba = fat_start + (offset / SECTOR_SIZE);
     const index = @as(usize, offset % SECTOR_SIZE);
-    var sector_buf: [SECTOR_SIZE]u8 = undefined;
     readSector(lba, sector_buf[0..]);
     const b0: u8 = sector_buf[index];
     var b1: u8 = 0;
     if (index + 1 < SECTOR_SIZE) {
         b1 = sector_buf[index + 1];
     } else {
-        var next_buf: [SECTOR_SIZE]u8 = undefined;
         readSector(lba + 1, next_buf[0..]);
         b1 = next_buf[0];
     }
@@ -746,13 +760,11 @@ fn fatEntry(cluster: u16) u16 {
     }
 }
 
-fn setFatEntry(cluster: u16, value: u16) void {
+fn setFatEntry(cluster: u16, value: u16, sector_buf: *[SECTOR_SIZE]u8, next_buf: *[SECTOR_SIZE]u8) void {
     const fat_start = VOLUME_START_LBA + RESERVED_SECTORS;
     const offset = @as(u32, cluster) + (@as(u32, cluster) / 2);
     const base_lba = fat_start + (offset / SECTOR_SIZE);
     const index = @as(usize, offset % SECTOR_SIZE);
-    var sector_buf: [SECTOR_SIZE]u8 = undefined;
-    var next_buf: [SECTOR_SIZE]u8 = undefined;
     var fat_index: u8 = 0;
     const val = value & 0x0FFF;
     while (fat_index < NUM_FATS) : (fat_index += 1) {
@@ -787,11 +799,11 @@ fn setFatEntry(cluster: u16, value: u16) void {
     }
 }
 
-fn clearFatChain(start: u16) void {
+fn clearFatChain(start: u16, sector_buf_a: *[SECTOR_SIZE]u8, sector_buf_b: *[SECTOR_SIZE]u8) void {
     var cluster = start;
     while (cluster >= 2 and cluster < 0xFFF8) {
-        const next = fatEntry(cluster);
-        setFatEntry(cluster, 0);
+        const next = fatEntry(cluster, sector_buf_a, sector_buf_b);
+        setFatEntry(cluster, 0, sector_buf_a, sector_buf_b);
         cluster = next;
     }
 }
@@ -803,68 +815,56 @@ fn compactRootDirectory() void {
     const root_start = VOLUME_START_LBA + RESERVED_SECTORS + (@as(u32, NUM_FATS) * fat_secs);
     const root_secs = rootDirSectors();
 
-    // Read all root directory sectors into a buffer
-    var all_entries: [ROOT_ENTRIES][DIR_ENTRY_SIZE]u8 = undefined;
-    var sector_buf: [SECTOR_SIZE]u8 = undefined;
-
     var lba: u32 = root_start;
-    var entry_idx: usize = 0;
+    var read_entry_idx: usize = 0;
     var remaining: u16 = root_secs;
 
-    // Read all entries
-    while (remaining > 0) : ({
+    var read_sector = &sector_bufs[0];
+    var write_sector = &sector_bufs[1];
+
+    var write_offset: u32 = 0;
+    var write_sector_index: u32 = 0;
+    // Read all entries, copying to compacted sector
+    read_loop: while (remaining > 0) : ({
         lba += 1;
         remaining -= 1;
     }) {
-        readSector(lba, sector_buf[0..]);
-        var i: usize = 0;
-        while (i < SECTOR_SIZE and entry_idx < ROOT_ENTRIES) : (i += DIR_ENTRY_SIZE) {
-            @memcpy(&all_entries[entry_idx], sector_buf[i .. i + DIR_ENTRY_SIZE]);
-            entry_idx += 1;
+        readSector(lba, read_sector);
+        var read_offset: usize = 0;
+        while (read_offset < SECTOR_SIZE and read_entry_idx < ROOT_ENTRIES) : (read_offset += DIR_ENTRY_SIZE) {
+            const entry = read_sector[read_offset..][0..DIR_ENTRY_SIZE];
+            read_entry_idx += 1;
+    
+            // Stop at end of directory marker
+            if (entry[0] == 0x00) break :read_loop;
+
+            // Skip deleted entries (0xE5) - don't copy them
+            if (entry[0] == 0xE5) continue;
+
+            // Copy valid entry to write position
+            write_sector[write_offset..][0..DIR_ENTRY_SIZE].* = entry.*;
+            write_offset += DIR_ENTRY_SIZE;
+
+            // Flush write sector if full
+            if (write_offset >= SECTOR_SIZE) {
+                writeSector(root_start + write_sector_index, write_sector);
+                write_sector_index += 1;
+                write_offset = 0;
+            }
         }
     }
 
-    // Compact: move all non-deleted entries to the front
-    var write_idx: usize = 0;
-    var read_idx: usize = 0;
+    // Fill the rest with zeroes
+    if (write_sector_index < root_secs) {
+        @memset(write_sector[write_offset..], 0);
+        writeSector(root_start + write_sector_index, write_sector);
+        write_sector_index += 1;
 
-    while (read_idx < ROOT_ENTRIES) : (read_idx += 1) {
-        const entry = all_entries[read_idx][0..];
-
-        // Stop at end of directory marker
-        if (entry[0] == 0x00) break;
-
-        // Skip deleted entries (0xE5) - don't copy them
-        if (entry[0] == 0xE5) continue;
-
-        // Copy valid entry to write position
-        if (write_idx != read_idx) {
-            @memcpy(&all_entries[write_idx], entry);
+        @memset(write_sector[0..write_offset], 0);
+        while (write_sector_index < root_secs) {
+            writeSector(root_start + write_sector_index, write_sector);
+            write_sector_index += 1;
         }
-        write_idx += 1;
-    }
-
-    // Zero out remaining entries and add end-of-directory marker
-    all_entries[write_idx][0] = 0x00; // End marker
-    while (write_idx < ROOT_ENTRIES) : (write_idx += 1) {
-        @memset(&all_entries[write_idx], 0);
-    }
-
-    // Write compacted directory back to flash
-    lba = root_start;
-    entry_idx = 0;
-    remaining = root_secs;
-
-    while (remaining > 0) : ({
-        lba += 1;
-        remaining -= 1;
-    }) {
-        var i: usize = 0;
-        while (i < SECTOR_SIZE and entry_idx < ROOT_ENTRIES) : (i += DIR_ENTRY_SIZE) {
-            @memcpy(sector_buf[i .. i + DIR_ENTRY_SIZE], &all_entries[entry_idx]);
-            entry_idx += 1;
-        }
-        writeSector(lba, sector_buf[0..]);
     }
 }
 

--- a/src/os/loader/storage.zig
+++ b/src/os/loader/storage.zig
@@ -236,7 +236,8 @@ fn isFormatted() bool {
         return false;
     }
     readSector(1, sector_buf[0..]); // fat0 sector
-    const valid = sector_buf[0] == MEDIA_DESCRIPTOR and sector_buf[1] == 0xFF and sector_buf[2] == 0xFF and sector_buf[3] & 0xF == 0xF;
+    // FAT12 sector starts with the media descriptor FAT entry (0xFF8) followed by the end of chain (0xFFF)
+    const valid = sector_buf[0] == MEDIA_DESCRIPTOR and sector_buf[1] == 0xFF and sector_buf[2] == 0xFF;
     return valid;
 }
 
@@ -287,21 +288,22 @@ fn formatVolume() void {
 
     const fat_start = RESERVED_SECTORS;
     const fat_secs = fatSectors();
-    @memset(sector_buf[4..], 0);
+    @memset(sector_buf, 0);
     var fat_index: u8 = 0;
     while (fat_index < NUM_FATS) : (fat_index += 1) {
         var i: u16 = 0;
         while (i < fat_secs) : (i += 1) {
             const lba = fat_start + (@as(u32, fat_index) * fat_secs) + i;
             if (i == 0) {
-                // First sector of FAT has media descriptor
+                // First sector of FAT has media descriptor.
+                // This is FAT12, so the first entry is 0xFF8,
+                // and the second is the End Of Chain value 0xFFF.
                 sector_buf[0] = MEDIA_DESCRIPTOR;
                 sector_buf[1] = 0xFF;
                 sector_buf[2] = 0xFF;
-                sector_buf[3] = 0x0F;
             } else {
                 // Subsequent FAT sectors are all zeros
-                @memset(sector_buf[0..4], 0);
+                @memset(sector_buf[0..3], 0);
             }
             writeSector(lba, sector_buf);
         }

--- a/src/os/system/fps_overlay.zig
+++ b/src/os/system/fps_overlay.zig
@@ -17,6 +17,13 @@ var last_frame_us: u64 = 0;
 /// Timestamp (µs) of the most recent poll() call.
 var last_poll_us: u64 = 0;
 
+/// Time spent mixing audio
+var audio_pct_sample_start: u64 = 0;
+var audio_mix_count: u32 = 0;
+var audio_mix_total_us: u32 = 0;
+var audio_mix_max_us: u32 = 0;
+var audio_service_delay_max_us: u32 = 0;
+
 // ── Rolling averages ───────────────────────────────────────────────────────────
 // multi-sample ring buffer so the display doesn't jitter on minor frame-time
 // variations.  Pre-filled with ~30 fps so the counter looks sane on first show.
@@ -51,6 +58,10 @@ fn AveragingBuffer(comptime T: type, comptime window: u32) type {
 var frame_times: AveragingBuffer(u32, 8) = .{};
 var poll_max_history: AveragingBuffer(u32, 32) = .{};
 var poll_max: u32 = 0;
+var audio_mix_times: AveragingBuffer(u32, 8) = .{};
+var audio_percent: AveragingBuffer(f32, 8) = .{};
+var display_max_audio: u32 = 0;
+var display_max_audio_delay: u32 = 0;
 
 // ── Overlay geometry (top-right corner) ──────────────────────────────────────
 // Font: 8×8 pixels per character at size 1.
@@ -148,7 +159,7 @@ pub fn isEnabled() bool {
 }
 
 fn time_delta(from: u64, to: u64) u32 {
-    if (from >= to) return 0;
+    if (from >= to or from == 0) return 0;
 
     const elapsed_u64 = to - from;
     // Clamp to u32; any single frame longer than ~71 minutes maps to max.
@@ -176,6 +187,15 @@ pub fn tick() void {
     update_debug_text();
 }
 
+pub fn submit_audio_mix_time(start: u64, end: u64, req: u64) void {
+    const service_delay: u32 = time_delta(req, start);
+    const mix_time: u32 = time_delta(start, end);
+    audio_mix_count += 1;
+    audio_mix_total_us += mix_time;
+    audio_mix_max_us = @max(audio_mix_max_us, mix_time);
+    audio_service_delay_max_us = @max(audio_service_delay_max_us, service_delay);
+}
+
 pub fn poll() void {
     // Update the poll timer
     const now = timer.micros();
@@ -183,6 +203,28 @@ pub fn poll() void {
         const elapsed = time_delta(last_poll_us, now);
         poll_max = @max(poll_max, elapsed);
     }
+
+    if (audio_pct_sample_start == 0) {
+        audio_pct_sample_start = now;
+    } else if (now - audio_pct_sample_start >= 150_000) {
+        const total_time = time_delta(audio_pct_sample_start, now);
+        const audio_time = audio_mix_total_us;
+        const audio_pct = @as(f32, @floatFromInt(audio_time)) / @as(f32, @floatFromInt(total_time));
+
+        if (audio_time != 0) {
+            audio_percent.submit(audio_pct);
+            audio_mix_times.submit(audio_time / audio_mix_count);
+        }
+        display_max_audio = audio_mix_max_us;
+        display_max_audio_delay = audio_service_delay_max_us;
+
+        audio_mix_total_us = 0;
+        audio_mix_count = 0;
+        audio_mix_max_us = 0;
+        audio_service_delay_max_us = 0;
+        audio_pct_sample_start = now;
+    }
+
     last_poll_us = now;
 }
 
@@ -238,6 +280,23 @@ fn update_debug_text() void {
 
         const read_str = std.fmt.bufPrint(&buf, "{d}", .{reading}) catch "!@*?";
         add_debug_text(.{ .text = read_str, .x = lcd.width, .y = lcd.height - font_height, .alignment = .right, .color = lcd.WHITE });
+    }
+
+    // Audio time
+    const audio_avg_str = std.fmt.bufPrint(&buf, "{d:>3}%", .{@as(u32, @intFromFloat(audio_percent.average() * 100))}) catch "!!!!";
+    add_debug_text(.{ .text = audio_avg_str, .x = 0, .y = 0, .alignment = .left, .color = lcd.GREEN });
+
+    const audio_time_str = std.fmt.bufPrint(&buf, "{d:>4}", .{audio_mix_times.average()}) catch "!!!!";
+    add_debug_text(.{ .text = audio_time_str, .x = 0, .y = 8, .alignment = .left, .color = lcd.BLUE });
+
+    if (display_max_audio_delay != 0) {
+        const audio_delay_str = std.fmt.bufPrint(&buf, "{d:>4}", .{display_max_audio_delay}) catch "!!!!";
+        add_debug_text(.{ .text = audio_delay_str, .x = 4*font_width, .y = 0, .alignment = .left, .color = lcd.RED });
+    }
+
+    if (display_max_audio != 0) {
+        const audio_max_str = std.fmt.bufPrint(&buf, "{d:>4}", .{display_max_audio}) catch "!!!!";
+        add_debug_text(.{ .text = audio_max_str, .x = 4*font_width, .y = font_height, .alignment = .left, .color = lcd.RED });
     }
 }
 

--- a/src/os/system/init.zig
+++ b/src/os/system/init.zig
@@ -36,6 +36,7 @@ extern const __scratch_x_region_start__: u8;
 extern const __scratch_x_region_end__: u8;
 extern const __scratch_y_region_start__: u8;
 extern const __scratch_y_region_end__: u8;
+extern const __stack_limit__: u8;
 
 fn clearRange(start: usize, end: usize) void {
     if (end > start) {
@@ -53,6 +54,13 @@ fn readMsp() usize {
 }
 
 fn clearOnBoot() void {
+    // Set the stack limit
+    asm volatile (
+        \\  msr msplim, %[splim]
+        :
+        : [splim] "r" (&__stack_limit__)
+    );
+
     // Clear kernel RAM after .bss (heap/shared_mem/unused).
     clearRange(@intFromPtr(&__bss_end__), @intFromPtr(&__kernel_ram_end__));
 


### PR DESCRIPTION
This PR has a few features and fixes:
- Fix: Put the stack at 0x20082000 instead of 0x20080000, by specifying __stack in build.zig
- Fix: Set MSPLIM to 0x20081000 so stack overflows will trap
- Fix: Change parts of storage.zig to avoid stack overflows
- Fix: Fix dirty rect cart buffers being drawn in the wrong place when not centered
- Feature: triangle and sawtooth waves are now implemented including volume control
- Feature: audio cart demos different wave shapes

The waves are implemented with an audio mixer that runs in audio.poll(). Mixed audio is written into two buffers, and DMA channels 1 and 2 alternate between these buffers writing them to the duty cycle of the PWM output.

When DMA finishes writing a buffer, an interrupt fires that marks it as ready to be mixed again. The next call to poll() will see this flag and trigger the mixing routine. This must happen quickly, as the two DMAs will continue running whether or not mixing happens. If mixing doesn't happen in time, the old data will be sent to the speaker, causing an audio hitch.

To help diagnose any future issues with this timing, new counters have been added to the debug display.
The top left percentage is the percent of total OS CPU time that is spent on audio mixing.
To its right is the maximum latency between when a DMA finished and when mixing started. This number needs to stay low.
Below that is the maximum time spent mixing one buffer.
And finally to the left of that is the average of these maximum times over the last second.
<img width="4032" height="2268" alt="image" src="https://github.com/user-attachments/assets/43be50a4-7e89-4323-9045-0b2b9bf28ef4" />
